### PR TITLE
Add missing imports in `Computational`

### DIFF
--- a/src/Class/Computational.agda
+++ b/src/Class/Computational.agda
@@ -12,6 +12,8 @@ open import Class.Bifunctor
 open import Class.DecEq
 open import Class.Functor renaming (fmap to map)
 open import Class.Monad
+open import Class.Semigroup
+open import Class.Show.Core
 open import Function
 open import Relation.Binary.PropositionalEquality
 


### PR DESCRIPTION
This PR adds missing imports in `Computational` that allow the `Show` instance for `ComputationResult` to typecheck.