### PR TITLE
Some extra properties of `STS`s

### DIFF
--- a/src/Prelude/STS/Properties.agda
+++ b/src/Prelude/STS/Properties.agda
@@ -58,7 +58,7 @@ module _ ⦃ ht : HasTransition Γ S I ⦄ where
 
   module _
     ⦃ _ : Computational _⊢_—[_]→_ ⦄
-    (let open Computational Computational∗ renaming (compute to compute∗; decidable to decidable∗; completeness to completeness∗)
+    (let open Computational Computational∗ renaming (compute to compute∗; decidable to decidable∗; completeness to completeness∗))
     where
 
     -- An equivalent version of `compute` for the reflexive-transitive closure

--- a/src/Prelude/STS/Properties.agda
+++ b/src/Prelude/STS/Properties.agda
@@ -58,9 +58,7 @@ module _ ⦃ ht : HasTransition Γ S I ⦄ where
 
   module _
     ⦃ _ : Computational _⊢_—[_]→_ ⦄
-    (let compute∗      = Computational.compute      Computational∗
-         decidable∗    = Computational.decidable    Computational∗
-         completeness∗ = Computational.completeness Computational∗)
+    (let open Computational Computational∗ renaming (compute to compute∗; decidable to decidable∗; completeness to completeness∗)
     where
 
     -- An equivalent version of `compute` for the reflexive-transitive closure


### PR DESCRIPTION
This PR adds some extra properties of `STS`s, namely:

1. An alternative definition of `compute` for the reflexive-transitive closure, which is equivalent to the original version.
2. The property that every left-total relation of an `STS` is always decidable and that its refexive-transitive closure is also left-total.